### PR TITLE
Adds default button classes to template.

### DIFF
--- a/src/Select.soy
+++ b/src/Select.soy
@@ -39,7 +39,7 @@
 			{param expanded: $disabled ? false : $expanded_ /}
 			{param header kind="html"}
 				<button
-					class="{$buttonClass ? $buttonClass : ''} dropdown-select"
+					class="{$buttonClass ?: 'btn btn-default'} dropdown-select"
 					disabled="{$disabled}"
 					type="button"
 					data-onclick="toggle"
@@ -50,7 +50,7 @@
 					{else}
 						{$items[$currSelectedIndex]}
 					{/if}
-					{sp}<span class="{$arrowClass ? $arrowClass : 'caret'}"></span>
+					{sp}<span class="{$arrowClass ?: 'caret'}"></span>
 				</button>
 			{/param}
 			{param ref: 'dropdown' /}

--- a/test/Select.js
+++ b/test/Select.js
@@ -485,5 +485,21 @@ describe('Select', function() {
 			});
 			assert.strictEqual('', element.childNodes[0].querySelector('input[type="hidden"]').value);
 		});
+
+		it('should add default button classes in template', () => {
+			const element = document.createElement('div');
+			IncrementalDOM.patch(element, () => {
+				Select.TEMPLATE({
+					id: 'select',
+					items: [],
+					values: []
+				});
+			});
+
+			const classNames = Select.STATE.buttonClass.value.split(' ');
+			const buttonElement = element.querySelector('button');
+
+			classNames.forEach(className => assert.isTrue(dom.hasClass(buttonElement, className)));
+		});
 	});
 });


### PR DESCRIPTION
Using the default value for `buttonClass` would lead to a flash when rendered on the server. This updates the template so that `buttonClass` is handled the same as `arrowClass`.